### PR TITLE
the user ip should be passed as uip not uid

### DIFF
--- a/src/Racecore/GATracking/GATracking.php
+++ b/src/Racecore/GATracking/GATracking.php
@@ -302,7 +302,7 @@ class GATracking
                 $payloadData['ua'] = $proxy['user_agent'];
             }
 
-            $payloadData['uid'] = $proxy['ip'];
+            $payloadData['uip'] = $proxy['ip'];
         }
 
         return array_filter($payloadData);


### PR DESCRIPTION
According to the [Google Analytics Measurement Protocol Parameter Reference Guide](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#uip), the IP override should be sent as 'uip' not as 'uid'.