### PR TITLE
Improved createConnection robustness and Exception throwing

### DIFF
--- a/src/Racecore/GATracking/Client/Adapter/Socket.php
+++ b/src/Racecore/GATracking/Client/Adapter/Socket.php
@@ -26,13 +26,13 @@ class Socket extends Client\AbstractClientAdapter
         if (!($connection = socket_create(AF_INET, SOCK_STREAM, SOL_TCP))) {
             $errorcode = socket_last_error();
             $errormsg = socket_strerror($errorcode);
-            throw new Exception\EndpointServerException('Analytics Socket failure! Error:' . $errormsg);
+            throw new Exception\EndpointServerException('Analytics Socket failure! Error: ' . $errormsg);
         }
 	
         if (!socket_connect($connection, $endpoint['host'], $port)) {
             $errorcode = socket_last_error();
             $errormsg = socket_strerror($errorcode);
-            throw new Exception\EndpointServerException('Analytics Host not reachable! Error:' . $errormsg);
+            throw new Exception\EndpointServerException('Analytics Host not reachable! Error: ' . $errormsg);
         }
 
         socket_set_option($connection, SOL_SOCKET, SO_RCVTIMEO, array('sec' => self::READ_TIMEOUT, 'usec' => 0));
@@ -68,7 +68,7 @@ class Socket extends Client\AbstractClientAdapter
         if (!socket_write($this->connection, $header) || !socket_write($this->connection, $payloadString)) {
             $errorcode = socket_last_error();
             $errormsg = socket_strerror($errorcode);
-            throw new Exception\EndpointServerException('Server closed connection unexpectedly' . $errormsg);
+            throw new Exception\EndpointServerException('Server closed connection unexpectedly. Error: ' . $errormsg);
         }
 
         return $header;

--- a/src/Racecore/GATracking/Client/Adapter/Socket.php
+++ b/src/Racecore/GATracking/Client/Adapter/Socket.php
@@ -28,7 +28,7 @@ class Socket extends Client\AbstractClientAdapter
             $errormsg = socket_strerror($errorcode);
             throw new Exception\EndpointServerException('Analytics Socket failure! Error: ' . $errormsg);
         }
-	
+
         if (!socket_connect($connection, $endpoint['host'], $port)) {
             $errorcode = socket_last_error();
             $errormsg = socket_strerror($errorcode);

--- a/src/Racecore/GATracking/Client/Adapter/Socket.php
+++ b/src/Racecore/GATracking/Client/Adapter/Socket.php
@@ -24,16 +24,16 @@ class Socket extends Client\AbstractClientAdapter
         $port = $this->getOption('ssl') == true ? 443 : 80;
 
         if (!($connection = socket_create(AF_INET, SOCK_STREAM, SOL_TCP))) {
-			$errorcode = socket_last_error();
-			$errormsg = socket_strerror($errorcode);
+            $errorcode = socket_last_error();
+            $errormsg = socket_strerror($errorcode);
             throw new Exception\EndpointServerException('Analytics Socket failure! Error:' . $errormsg);
         }
 		
         if (!socket_connect($connection, $endpoint['host'], $port)) {
-			$errorcode = socket_last_error();
-			$errormsg = socket_strerror($errorcode);
+            $errorcode = socket_last_error();
+            $errormsg = socket_strerror($errorcode);
             throw new Exception\EndpointServerException('Analytics Host not reachable! Error:' . $errormsg);
-		}
+        }
 
         socket_set_option($connection, SOL_SOCKET, SO_RCVTIMEO, array('sec' => self::READ_TIMEOUT, 'usec' => 0));
 
@@ -66,8 +66,8 @@ class Socket extends Client\AbstractClientAdapter
 
         // fwrite + check if fwrite was ok
         if (!socket_write($this->connection, $header) || !socket_write($this->connection, $payloadString)) {
-			$errorcode = socket_last_error();
-			$errormsg = socket_strerror($errorcode);
+            $errorcode = socket_last_error();
+            $errormsg = socket_strerror($errorcode);
             throw new Exception\EndpointServerException('Server closed connection unexpectedly' . $errormsg);
         }
 

--- a/src/Racecore/GATracking/Client/Adapter/Socket.php
+++ b/src/Racecore/GATracking/Client/Adapter/Socket.php
@@ -28,7 +28,7 @@ class Socket extends Client\AbstractClientAdapter
             $errormsg = socket_strerror($errorcode);
             throw new Exception\EndpointServerException('Analytics Socket failure! Error:' . $errormsg);
         }
-		
+	
         if (!socket_connect($connection, $endpoint['host'], $port)) {
             $errorcode = socket_last_error();
             $errormsg = socket_strerror($errorcode);


### PR DESCRIPTION
socket_connect could return FALSE because no Internet connection is available.
The code change considers the case and throws an additional exception.
Exceptions now have an error message based on socket_last_error.

See http://www.binarytides.com/php-socket-programming-tutorial/ as reference.

Corrected a typo in the function name createConnection.